### PR TITLE
feat: add website customizability options for restaurant owners

### DIFF
--- a/silverplatter.client/src/Pages/RestaurantSpecific.tsx
+++ b/silverplatter.client/src/Pages/RestaurantSpecific.tsx
@@ -1,12 +1,18 @@
 import Gallery from "../Components/Gallery";
 import Menu from "../Components/Menu";
 import "./css/RestaurantSpecific.css"
+import { useState } from "react";
 
 function bookTable() {
     // Something
 }
 
 function RestaurantSpecific() {
+    const [isRestaurantOwner] = useState(true);
+    const [bgColor, setBgColor] = useState("#007bff"); // default background
+    const [textColor, setTextColor] = useState("#ffffff"); // default text
+    const [flexDirection, setFlexDirection] = useState<"row" | "column">("column"); // flexlayout
+
     let tempRestaurant = {
         Id: 0,
         Name: "Temporary Restaurant",
@@ -15,7 +21,13 @@ function RestaurantSpecific() {
     }
 
     return (
-        <div className="RestaurantFrontpage">
+        <div className={`RestaurantFrontPage custom-theme`}  
+            style={{
+                "--theme-bg": bgColor,
+                "--theme-text": textColor,
+                "--flex-direction": flexDirection // CSS variable for layout
+            } as React.CSSProperties}
+        >
             <div className="RestaurantFrontSection">
                 <div className="RestaurantHeader">
                     <h1>{tempRestaurant.Name}</h1>
@@ -40,6 +52,43 @@ function RestaurantSpecific() {
                     </button>
                 </section>
             </div>
+
+            {isRestaurantOwner && (
+                <section className="EditRestaurant">
+                <div>
+                    <label>
+                    Background color:{" "}
+                    <input
+                        type="color"
+                        value={bgColor}
+                        onChange={(e) => setBgColor(e.target.value)}
+                    />
+                    </label>
+                </div>
+                <div>
+                    <label>
+                    Text color:{" "}
+                    <input
+                        type="color"
+                        value={textColor}
+                        onChange={(e) => setTextColor(e.target.value)}
+                    />
+                    </label>
+                </div>
+                <div>
+                    <label>
+                        Layout direction:{" "}
+                        <select
+                            value={flexDirection}
+                            onChange={(e) => setFlexDirection(e.target.value as "row" | "column")}
+                        >
+                            <option value="row">Row</option>
+                            <option value="column">Column</option>
+                        </select>
+                    </label>
+                </div>
+                </section>
+            )}
 
             <section className="Utilities">
                 <div className="Menu">

--- a/silverplatter.client/src/Pages/css/RestaurantSpecific.css
+++ b/silverplatter.client/src/Pages/css/RestaurantSpecific.css
@@ -11,6 +11,14 @@
     overflow-x: hidden;
 }
 
+/* Custom theme */
+.custom-theme {
+  background-color: var(--theme-bg);
+  color: var(--theme-text);
+  flex-direction: var(--flex-direction);
+}
+
+
 .RestaurantFrontSection {
     background-image: url("/src/assets/2431225-uhd_3840_2160_24fps.gif");
     background-size: 100vw;


### PR DESCRIPTION
# feat: add website customizability options for restaurantowners

Add website customizability options for restaurantowners by using css variables and user inputs that are only available for restaurant owners.

<img width="2803" height="1461" alt="image" src="https://github.com/user-attachments/assets/5b33d109-f612-4710-b745-2bf728e6de36" />


Closes: #31 